### PR TITLE
add conf params for hide some specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MACKEREL_AGENT_NAME ?= "mackerel-agent"
 MACKEREL_API_BASE ?= "https://api.mackerelio.com"
-VERSION = 0.56.0
+VERSION = 0.56.1
 CURRENT_REVISION = $(shell git rev-parse --short HEAD)
 ARGS = "-conf=mackerel-agent.conf"
 BUILD_OS_TARGETS = "linux darwin freebsd windows netbsd"

--- a/command/command.go
+++ b/command/command.go
@@ -561,7 +561,7 @@ func collectHostSpecs(conf *config.Config, ameta *AgentMeta) (mackerel.HostSpec,
 	if cGen != nil {
 		specGens = append(specGens, cGen)
 	}
-	meta := spec.Collect(specGens)
+	meta := spec.Collect(conf, specGens)
 
 	var customIdentifier string
 	if cGen != nil {
@@ -575,6 +575,9 @@ func collectHostSpecs(conf *config.Config, ameta *AgentMeta) (mackerel.HostSpec,
 	if err != nil {
 		return mackerel.HostSpec{}, fmt.Errorf("failed to collect interfaces: %s", err.Error())
 	}
+	if conf.HideInterface == true {
+		interfaces = nil
+        }
 
 	meta.AgentVersion = ameta.Version
 	meta.AgentRevision = ameta.Revision

--- a/config/config.go
+++ b/config/config.go
@@ -102,6 +102,9 @@ type Config struct {
 	Roles         []string
 	Verbose       bool
 	Silent        bool
+	HideCpu       bool
+	HideKernel    bool
+	HideInterface bool
 	Diagnostic    bool          `toml:"diagnostic"`
 	DisplayName   string        `toml:"display_name"`
 	HostStatus    HostStatus    `toml:"host_status"`

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"github.com/mackerelio/golib/logging"
 	"github.com/mackerelio/mackerel-client-go"
+	"github.com/mackerelio/mackerel-agent/config"
 )
 
 var logger = logging.GetLogger("spec")
@@ -13,7 +14,7 @@ type Generator interface {
 }
 
 // Collect spec values
-func Collect(specGenerators []Generator) mackerel.HostMeta {
+func Collect(conf *config.Config, specGenerators []Generator) mackerel.HostMeta {
 	var specs mackerel.HostMeta
 	for _, g := range specGenerators {
 		value, err := g.Generate()
@@ -25,11 +26,19 @@ func Collect(specGenerators []Generator) mackerel.HostMeta {
 		case mackerel.BlockDevice:
 			specs.BlockDevice = v
 		case mackerel.CPU:
-			specs.CPU = v
+                        if conf.HideCpu == true {
+			  specs.CPU = nil
+                        } else {
+			  specs.CPU = v
+                        }
 		case mackerel.FileSystem:
 			specs.Filesystem = v
 		case mackerel.Kernel:
-			specs.Kernel = v
+                        if conf.HideKernel == true {
+			  specs.Kernel = nil
+                        } else {
+			  specs.Kernel = v
+                        }
 		case mackerel.Memory:
 			specs.Memory = v
 		case *mackerel.Cloud:

--- a/version.go
+++ b/version.go
@@ -1,5 +1,5 @@
 package main
 
-const version = "0.56.0"
+const version = "0.56.1"
 
 var gitcommit string


### PR DESCRIPTION
hidecpu = true
hidekernel = true
hideinterface = true
をmackerel-agent.confに追加すると、CPU, Kernel, ネットワークの情報を送らずに、非表示にする。